### PR TITLE
Fix `robot_active` field

### DIFF
--- a/c1t_vesc_driver/src/c1t_vesc_driver.cpp
+++ b/c1t_vesc_driver/src/c1t_vesc_driver.cpp
@@ -60,6 +60,7 @@ void VescDriverWrapper::initialize()
   robot_status_timer_ = nh_->createTimer(ros::Duration(0.1), [this](const ros::TimerEvent& event) {
     cav_msgs::RobotEnabled msg;
 
+    msg.robot_active = true;
     msg.robot_enabled = this->enabled_;
 
     this->robot_states_pub_.publish(msg);

--- a/c1t_vesc_driver/src/c1t_vesc_driver.cpp
+++ b/c1t_vesc_driver/src/c1t_vesc_driver.cpp
@@ -60,7 +60,7 @@ void VescDriverWrapper::initialize()
   robot_status_timer_ = nh_->createTimer(ros::Duration(0.1), [this](const ros::TimerEvent& event) {
     cav_msgs::RobotEnabled msg;
 
-    msg.robot_active = true;
+    msg.robot_active = this->enabled_;
     msg.robot_enabled = this->enabled_;
 
     this->robot_states_pub_.publish(msg);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

This PR fixes the `robot_active` field to equal the `robot_enabled` field. Previously, the `robot_active` field was always `true`, 
which deviated from the field's intended purpose. It also caused issues with the `guidance` node's state transitions.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #3 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The previous implementation deviated from the `robot_active` field's intended use, and it prevented the `guidance` node from transitioning to the `ENGAGED` state.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Proposed changes were tested successfully on the C1T vehicle.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.